### PR TITLE
Added title attribute to closed windows

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -56,7 +56,7 @@
 				}
 				html += '<li><span class="time">' + date.get12HourTime() + '</span> ';
 				html += '<img width="16" height="16" src="' + data.removed[i].favIconUrl + '"/>';
-				html += '<a href="' + data.removed[i].url + '">' + ((data.removed[i].title.length > 50) ? data.removed[i].title.substr(0, 50) + '&hellip;' : data.removed[i].title) + '</a></li>';
+				html += '<a href="' + data.removed[i].url + '" title="' + data.removed[i].url + '">' + ((data.removed[i].title.length > 50) ? data.removed[i].title.substr(0, 50) + '&hellip;' : data.removed[i].title) + '</a></li>';
 				lastDate = date;
 			}
 			html += '</ol>';


### PR DESCRIPTION
Added a title attribute to closed windows, showing the URL that was closed. This is helpful in cases where you're working on two identical pages, such as in dev and production. Otherwise there's no way to tell the difference.
